### PR TITLE
Update httpxxray module to v2

### DIFF
--- a/httpxxray/go.mod
+++ b/httpxxray/go.mod
@@ -1,4 +1,4 @@
-module github.com/gogama/aws-xray-httpx/httpxxray
+module github.com/gogama/aws-xray-httpx/httpxxray/v2
 
 go 1.14
 


### PR DESCRIPTION
According to Go's semantic import versioning rules, if you're 
releasing version v2.0.0 or higher of a module, you must include the major version 
suffix in the module path in your go.mod file.